### PR TITLE
Use kafka-python-ng instead

### DIFF
--- a/python/readme.md
+++ b/python/readme.md
@@ -12,7 +12,7 @@ python3 -m venv .env
 source .env/bin/activate
 # Install dependencies
 pip install --upgrade pip
-pip install kafka-python
+pip install kafka-python-ng
 ```
 
 ## Get credentials


### PR DESCRIPTION
In a fairly fresh host, using Python 3.12, I hit the following exception when running admin.py:

```
  File "/home/daisuke/Downloads/redpanda-python/.env/lib/python3.12/site-packages/kafka/codec.py", line 9, in <module>
    from kafka.vendor.six.moves import range
ModuleNotFoundError: No module named 'kafka.vendor.six.moves'
```

Using kafka-python-ng works, as suggested in the kafka-python project, https://github.com/dpkp/kafka-python.

```
$ pip uninstall kafka-python
$ pip install kafka-python-ng
```